### PR TITLE
feat: add config file location setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,23 @@
   "contributes": {
     "configuration": {
       "title": "%configuration.title%",
-      "properties": {}
+      "properties": {
+        "folder-alias.configLocation": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "vscode",
+            "root"
+          ],
+          "enumDescriptions": [
+            "%configuration.configLocation.enum.auto%",
+            "%configuration.configLocation.enum.vscode%",
+            "%configuration.configLocation.enum.root%"
+          ],
+          "description": "%configuration.configLocation.description%"
+        }
+      }
     },
     "commands": [
       {

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,10 @@
   "extension.displayName": "Folder Alias",
   "extension.description": "Customize aliases and tooltips for files and folders in the explorer tree",
   "configuration.title": "Folder Alias",
+  "configuration.configLocation.description": "Controls where folder-alias JSON files are saved.",
+  "configuration.configLocation.enum.auto": "Save under .vscode only when the alias file already exists there.",
+  "configuration.configLocation.enum.vscode": "Create .vscode and save alias files there.",
+  "configuration.configLocation.enum.root": "Save alias files in the workspace root.",
   "command.addAlias": "Add Alias",
   "command.refresh": "Refresh Aliases",
   "command.deleteAlias": "Delete Alias"

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -2,6 +2,10 @@
   "extension.displayName": "文件夹别名",
   "extension.description": "自定义资源管理器中文件和文件夹的别名与提示信息",
   "configuration.title": "文件夹别名",
+  "configuration.configLocation.description": "控制 folder-alias JSON 文件的保存位置。",
+  "configuration.configLocation.enum.auto": "仅当别名文件已存在于 .vscode 下时保存到 .vscode。",
+  "configuration.configLocation.enum.vscode": "创建 .vscode 并将别名文件保存到其中。",
+  "configuration.configLocation.enum.root": "将别名文件保存到工作区根目录。",
   "command.addAlias": "添加别名",
   "command.refresh": "刷新别名",
   "command.deleteAlias": "删除别名"

--- a/src/hooks/__tests__/useConfig.test.ts
+++ b/src/hooks/__tests__/useConfig.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEST_DIR = join(__dirname, "__fixtures__");
+let configLocation = "auto";
 
 // Mock reactive-vscode's ref/computed to work outside VS Code
 vi.mock("reactive-vscode", () => {
@@ -31,7 +32,16 @@ vi.mock("../../utils/logger.util", () => ({
   },
 }));
 
+vi.mock("vscode", () => ({
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key: string, defaultValue: string) => configLocation || defaultValue,
+    }),
+  },
+}));
+
 beforeEach(() => {
+  configLocation = "auto";
   mkdirSync(TEST_DIR, { recursive: true });
 });
 
@@ -98,5 +108,31 @@ describe("useConfig", () => {
 
     config.resetConfig();
     expect(config.publicConfig.value.src.description).toBe("V2");
+  });
+
+  it("should save public config to root when configLocation is root", async () => {
+    configLocation = "root";
+
+    const { useConfig } = await import("../useConfig");
+    const config = useConfig(TEST_DIR);
+    config.publicConfig.value = { src: { description: "Root" } };
+
+    config.savePublic();
+
+    expect(JSON.parse(readFileSync(join(TEST_DIR, "folder-alias.json"), "utf-8"))).toEqual(config.publicConfig.value);
+    expect(existsSync(join(TEST_DIR, ".vscode", "folder-alias.json"))).toBe(false);
+  });
+
+  it("should create .vscode and save private config there when configLocation is vscode", async () => {
+    configLocation = "vscode";
+
+    const { useConfig } = await import("../useConfig");
+    const config = useConfig(TEST_DIR);
+    config.privateConfig.value = { secret: { description: "Private" } };
+
+    config.savePrivate();
+
+    expect(JSON.parse(readFileSync(join(TEST_DIR, ".vscode", "private-folder-alias.json"), "utf-8"))).toEqual(config.privateConfig.value);
+    expect(existsSync(join(TEST_DIR, "private-folder-alias.json"))).toBe(false);
   });
 });

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,10 +1,10 @@
 import type { ComputedRef, Ref } from "reactive-vscode";
 import type { RecordConfig } from "../typings/common.typing";
-import { existsSync } from "node:fs";
+import type { ConfigLocation } from "../utils/file.util";
 import { merge } from "es-toolkit";
-import { join } from "pathe";
 import { computed, ref } from "reactive-vscode";
-import { readConfigWithVscodePriority, writeConfig } from "../utils/file.util";
+import { workspace } from "vscode";
+import { readConfigWithVscodePriority, resolveConfigPath, writeConfig } from "../utils/file.util";
 
 export interface UseConfigReturn {
   publicConfig: Ref<RecordConfig, RecordConfig>;
@@ -20,37 +20,23 @@ export function useConfig(fileDir: string): UseConfigReturn {
   const privateConfig = ref(readConfigWithVscodePriority(fileDir, "private-folder-alias.json"));
   const configFile = computed<RecordConfig>(() => merge(merge({}, publicConfig.value), privateConfig.value));
 
+  function getConfigLocation(): ConfigLocation {
+    return workspace.getConfiguration("folder-alias").get<ConfigLocation>("configLocation", "auto");
+  }
+
   function resetConfig() {
     publicConfig.value = readConfigWithVscodePriority(fileDir, "folder-alias.json");
     privateConfig.value = readConfigWithVscodePriority(fileDir, "private-folder-alias.json");
   }
 
   function savePublic() {
-    const vscodeConfigPath = join(fileDir, ".vscode", "folder-alias.json");
-    const rootConfigPath = join(fileDir, "folder-alias.json");
-
-    // 只在.vscode目录下存在配置文件时保存到.vscode目录
-    if (existsSync(vscodeConfigPath)) {
-      writeConfig(vscodeConfigPath, publicConfig.value);
-    }
-    else {
-      // 否则保存到根目录
-      writeConfig(rootConfigPath, publicConfig.value);
-    }
+    const configPath = resolveConfigPath(fileDir, "folder-alias.json", getConfigLocation());
+    writeConfig(configPath, publicConfig.value);
   }
 
   function savePrivate() {
-    const vscodeConfigPath = join(fileDir, ".vscode", "private-folder-alias.json");
-    const rootConfigPath = join(fileDir, "private-folder-alias.json");
-
-    // 只在.vscode目录下存在配置文件时保存到.vscode目录
-    if (existsSync(vscodeConfigPath)) {
-      writeConfig(vscodeConfigPath, privateConfig.value);
-    }
-    else {
-      // 否则保存到根目录
-      writeConfig(rootConfigPath, privateConfig.value);
-    }
+    const configPath = resolveConfigPath(fileDir, "private-folder-alias.json", getConfigLocation());
+    writeConfig(configPath, privateConfig.value);
   }
 
   return {

--- a/src/utils/__tests__/file.util.test.ts
+++ b/src/utils/__tests__/file.util.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -110,5 +110,44 @@ describe("writeConfig", () => {
     const content = readFileSync(configPath, "utf-8");
     expect(JSON.parse(content)).toEqual(data);
     expect(content).toContain("    ");
+  });
+});
+
+describe("resolveConfigPath", () => {
+  it("should use root config in auto mode when .vscode config does not exist", async () => {
+    const { resolveConfigPath } = await import("../file.util");
+
+    const result = resolveConfigPath(TEST_DIR, "folder-alias.json", "auto");
+
+    expect(result).toBe(join(TEST_DIR, "folder-alias.json"));
+  });
+
+  it("should use .vscode config in auto mode when .vscode config exists", async () => {
+    const { resolveConfigPath } = await import("../file.util");
+    const vscodeDir = join(TEST_DIR, ".vscode");
+    const vscodeConfigPath = join(vscodeDir, "folder-alias.json");
+    mkdirSync(vscodeDir, { recursive: true });
+    writeFileSync(vscodeConfigPath, "{}");
+
+    const result = resolveConfigPath(TEST_DIR, "folder-alias.json", "auto");
+
+    expect(result).toBe(vscodeConfigPath);
+  });
+
+  it("should create .vscode and use it in vscode mode", async () => {
+    const { resolveConfigPath } = await import("../file.util");
+
+    const result = resolveConfigPath(TEST_DIR, "private-folder-alias.json", "vscode");
+
+    expect(result).toBe(join(TEST_DIR, ".vscode", "private-folder-alias.json"));
+    expect(existsSync(join(TEST_DIR, ".vscode"))).toBe(true);
+  });
+
+  it("should use root config in root mode", async () => {
+    const { resolveConfigPath } = await import("../file.util");
+
+    const result = resolveConfigPath(TEST_DIR, "private-folder-alias.json", "root");
+
+    expect(result).toBe(join(TEST_DIR, "private-folder-alias.json"));
   });
 });

--- a/src/utils/file.util.ts
+++ b/src/utils/file.util.ts
@@ -1,8 +1,10 @@
 import type { RecordConfig } from "../typings/common.typing";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { destr } from "destr";
 import { join } from "pathe";
 import { logger } from "./logger.util";
+
+type ConfigLocation = "auto" | "vscode" | "root";
 
 function readConfig(configPath: string): RecordConfig {
   try {
@@ -34,6 +36,26 @@ function readConfigWithVscodePriority(basePath: string, fileName: string): Recor
   return {};
 }
 
+function resolveConfigPath(basePath: string, fileName: string, configLocation: ConfigLocation): string {
+  const vscodeConfigPath = join(basePath, ".vscode", fileName);
+  const rootConfigPath = join(basePath, fileName);
+
+  if (configLocation === "vscode") {
+    mkdirSync(join(basePath, ".vscode"), { recursive: true });
+    return vscodeConfigPath;
+  }
+
+  if (configLocation === "root") {
+    return rootConfigPath;
+  }
+
+  if (existsSync(vscodeConfigPath)) {
+    return vscodeConfigPath;
+  }
+
+  return rootConfigPath;
+}
+
 function writeConfig(configPath: string, config: RecordConfig): void {
   try {
     writeFileSync(configPath, JSON.stringify(config, null, 4));
@@ -43,4 +65,5 @@ function writeConfig(configPath: string, config: RecordConfig): void {
   }
 }
 
-export { readConfig, readConfigWithVscodePriority, writeConfig };
+export type { ConfigLocation };
+export { readConfig, readConfigWithVscodePriority, resolveConfigPath, writeConfig };


### PR DESCRIPTION
Add the folder-alias.configLocation setting with auto, vscode, and root save strategies.

Keep auto as the default to preserve existing behavior, and create the .vscode directory automatically when vscode mode is selected.

Add localized configuration descriptions and tests for save path resolution and config save behavior.